### PR TITLE
Allow Field Medic Kit to be backpackable

### DIFF
--- a/zscript/FieldMedicationKit.zsc
+++ b/zscript/FieldMedicationKit.zsc
@@ -15,6 +15,9 @@ class HDFieldMedicKit:HDWoundFixer{
 	    +weapon.no_auto_switch
 		+hdweapon.fitsinbackpack
 		
+		-weapon.cheatnotweapon
+		//adding this made it backpackable
+		
 		+inventory.invbar
 		-nointeraction
 		+inventory.ishealth


### PR DESCRIPTION
Cozi's Offworld Wares has a medical bag that allows the First Aid Spray, but not the Field Medical Kit.  Adding the flag allows it